### PR TITLE
Add link to the JSConf COC

### DIFF
--- a/about.html
+++ b/about.html
@@ -129,7 +129,13 @@
         policy
         is that speakers at the conference get paid for their travel and accommodation. We do not sell speaker slots and we do not accept sales pitches masked as presentations.</p>
       <h2 id="coc">Code of Conduct</h2>
-      <p>We want these couple of days to be truly enjoyable for everyone. Attendees, speakers, sponsors and volunteers must all respect the JSConf Code of Conduct. If anything happens that we should know about, contact a member of the crew.</p>
+      <p>
+        We want these couple of days to be truly enjoyable for everyone.
+        Attendees, speakers, sponsors and volunteers must all respect the
+        <a href="https://jsconf.com/codeofconduct.html">JSConf Code of Conduct</a>.
+        If anything happens that we should know about,
+        contact a member of the crew.
+      </p>
       <h2>Rebel Crew</h2>
       <p>The volunteers working to bring you the 8th Web Rebels Conference are:</p>
       <ul>


### PR DESCRIPTION
Why: so that folks know what the COC is.